### PR TITLE
feat: add driver image URL to all driver-related API endpoints

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: Rafacv23
+ko_fi: rafacanosa

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Project made with Next.js and Turso to take all the data about the Formula 1 Cha
 
 You can find all the available endpoints in the [docs](https://f1api.dev/docs) section of the website.
 
+An OpenAPI YAML specification is also available in this repository at [`openapi.yaml`](openapi.yaml), so you can use tools like OpenAPI Generator directly.
+
 ## 🪄 Official SDK to use the API
 
 You can use the official SDK to use the API. This is not mandatory, you can simply use fetch to get the data.

--- a/app/api/[year]/compare/[driverId1]/[driverId2]/route.ts
+++ b/app/api/[year]/compare/[driverId1]/[driverId2]/route.ts
@@ -3,7 +3,7 @@ import { driverClassifications, drivers } from "@/db/migrations/schema"
 import { SITE_URL } from "@/lib/constants"
 import { BaseApiResponse } from "@/lib/definitions"
 import { executeQuery } from "@/lib/executeQuery"
-import { apiNotFound } from "@/lib/utils"
+import { apiNotFound, getDriverImageUrl } from "@/lib/utils"
 import { and, eq, or } from "drizzle-orm"
 import { NextResponse } from "next/server"
 
@@ -56,6 +56,7 @@ type DriverInfo = {
   number: number | null
   shortName: string | null
   url: string | null
+  image: string
   teamId: string | null
 }
 
@@ -133,6 +134,7 @@ export async function GET(request: Request, context: any) {
         number: driversPointsData[0].Drivers.number,
         shortName: driversPointsData[0].Drivers.shortName,
         url: driversPointsData[0].Drivers.url,
+        image: getDriverImageUrl(driverId1),
         teamId: driversPointsData[0].Driver_Classifications.teamId,
       },
       {
@@ -144,6 +146,7 @@ export async function GET(request: Request, context: any) {
         number: driversPointsData[1].Drivers.number,
         shortName: driversPointsData[1].Drivers.shortName,
         url: driversPointsData[1].Drivers.url,
+        image: getDriverImageUrl(driverId2),
         teamId: driversPointsData[1].Driver_Classifications.teamId,
       },
     ]

--- a/app/api/[year]/drivers-championship/route.ts
+++ b/app/api/[year]/drivers-championship/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { SITE_NAME } from "@/lib/constants"
-import { apiNotFound, getLimitAndOffset } from "@/lib/utils"
+import { apiNotFound, getDriverImageUrl, getLimitAndOffset } from "@/lib/utils"
 import { BaseApiResponse } from "@/lib/definitions"
 import { db } from "@/db"
 import { driverClassifications, drivers, teams } from "@/db/migrations/schema"
@@ -53,6 +53,7 @@ export async function GET(request: Request, context: any) {
           number: driver.Drivers.number,
           shortName: driver.Drivers.shortName,
           url: driver.Drivers.url,
+          image: getDriverImageUrl(driver.Driver_Classifications.driverId ?? ""),
         },
         team: {
           teamId: driver.Teams.teamId,

--- a/app/api/[year]/drivers/[driverId]/route.tsx
+++ b/app/api/[year]/drivers/[driverId]/route.tsx
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { SITE_URL } from "@/lib/constants"
-import { apiNotFound, getLimitAndOffset } from "@/lib/utils"
+import { apiNotFound, getDriverImageUrl, getLimitAndOffset } from "@/lib/utils"
 import { BaseApiResponse } from "@/lib/definitions"
 import { db } from "@/db"
 import {
@@ -82,6 +82,7 @@ export async function GET(request: Request, context: any) {
         number: row.Drivers.number,
         shortName: row.Drivers.shortName,
         url: row.Drivers.url,
+        image: getDriverImageUrl(row.Drivers.driverId),
       }
     })
 

--- a/app/api/[year]/drivers/route.ts
+++ b/app/api/[year]/drivers/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { apiNotFound, getLimitAndOffset } from "@/lib/utils"
+import { apiNotFound, getDriverImageUrl, getLimitAndOffset } from "@/lib/utils"
 import { SITE_URL } from "@/lib/constants"
 import { BaseApiResponse } from "@/lib/definitions"
 import { db } from "@/db"
@@ -53,15 +53,20 @@ export async function GET(request: Request, context: any) {
       )
     }
 
+    const driversWithImages = driversData.map((driver) => ({
+      ...driver,
+      image: getDriverImageUrl(driver.driverId),
+    }))
+
     const response: ApiResponse = {
       api: SITE_URL,
       url: request.url,
       limit,
       offset,
-      total: driversData.length,
+      total: driversWithImages.length,
       season: parseInt(year),
       championshipId: `f1_${year}`,
-      drivers: driversData,
+      drivers: driversWithImages,
     }
 
     return NextResponse.json(response, {

--- a/app/api/[year]/teams/[teamId]/drivers/route.tsx
+++ b/app/api/[year]/teams/[teamId]/drivers/route.tsx
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { SITE_URL } from "@/lib/constants"
-import { apiNotFound, getLimitAndOffset } from "@/lib/utils"
+import { apiNotFound, getDriverImageUrl, getLimitAndOffset } from "@/lib/utils"
 import { BaseApiResponse } from "@/lib/definitions"
 import { db } from "@/db"
 import {
@@ -27,6 +27,7 @@ interface ApiResponse extends BaseApiResponse {
       number: number | null
       shortName: string | null
       url: string | null
+      image: string
     }
   }[]
 }
@@ -103,6 +104,7 @@ export async function GET(request: Request, context: any) {
           number: driver.drivers.number,
           shortName: driver.drivers.shortName,
           url: driver.drivers.url,
+          image: getDriverImageUrl(driver.drivers.driverId),
           points: driver.driverClassifications.points,
           position: driver.driverClassifications.position,
           wins: driver.driverClassifications.wins,

--- a/app/api/current/drivers-championship/route.tsx
+++ b/app/api/current/drivers-championship/route.tsx
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { CURRENT_YEAR, SITE_NAME } from "@/lib/constants"
-import { apiNotFound, getLimitAndOffset } from "@/lib/utils"
+import { apiNotFound, getDriverImageUrl, getLimitAndOffset } from "@/lib/utils"
 import { BaseApiResponse } from "@/lib/definitions"
 import { db } from "@/db"
 import { asc, eq } from "drizzle-orm"
@@ -52,6 +52,7 @@ export async function GET(request: Request) {
           number: driver.Drivers.number,
           shortName: driver.Drivers.shortName,
           url: driver.Drivers.url,
+          image: getDriverImageUrl(driver.Driver_Classifications.driverId ?? ""),
         },
         team: {
           teamId: driver.Teams.teamId,

--- a/app/api/current/drivers/[driverId]/route.tsx
+++ b/app/api/current/drivers/[driverId]/route.tsx
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { CURRENT_YEAR, SITE_URL } from "@/lib/constants"
-import { apiNotFound, getLimitAndOffset } from "@/lib/utils"
+import { apiNotFound, getDriverImageUrl, getLimitAndOffset } from "@/lib/utils"
 import { BaseApiResponse } from "@/lib/definitions"
 import { InferModel, and, eq } from "drizzle-orm"
 import { db } from "@/db"
@@ -83,6 +83,7 @@ export async function GET(request: Request, context: any) {
         number: row.Drivers.number,
         shortName: row.Drivers.shortName,
         url: row.Drivers.url,
+        image: getDriverImageUrl(row.Drivers.driverId),
       }
     })
 

--- a/app/api/current/drivers/route.tsx
+++ b/app/api/current/drivers/route.tsx
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { apiNotFound, getLimitAndOffset } from "@/lib/utils"
+import { apiNotFound, getDriverImageUrl, getLimitAndOffset } from "@/lib/utils"
 import { CURRENT_YEAR, SITE_URL } from "@/lib/constants"
 import { BaseApiResponse } from "@/lib/definitions"
 import { InferModel, eq, asc } from "drizzle-orm"
@@ -51,15 +51,20 @@ export async function GET(request: Request) {
       )
     }
 
+    const driversWithImages = driversData.map((driver) => ({
+      ...driver,
+      image: getDriverImageUrl(driver.driverId),
+    }))
+
     const response: ApiResponse = {
       api: SITE_URL,
       url: request.url,
       limit,
       offset,
-      total: driversData.length,
+      total: driversWithImages.length,
       season: year,
       championshipId: `f1_${year}`,
-      drivers: driversData,
+      drivers: driversWithImages,
     }
 
     return NextResponse.json(response, {

--- a/app/api/current/teams/[teamId]/drivers/route.tsx
+++ b/app/api/current/teams/[teamId]/drivers/route.tsx
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { CURRENT_YEAR, SITE_URL } from "@/lib/constants"
-import { apiNotFound, getLimitAndOffset } from "@/lib/utils"
+import { apiNotFound, getDriverImageUrl, getLimitAndOffset } from "@/lib/utils"
 import { BaseApiResponse } from "@/lib/definitions"
 import { db } from "@/db"
 import {
@@ -27,6 +27,7 @@ interface ApiResponse extends BaseApiResponse {
       number: number | null
       shortName: string | null
       url: string | null
+      image: string
     }
   }[]
 }
@@ -104,6 +105,7 @@ export async function GET(request: Request, context: any) {
           number: driver.drivers.number,
           shortName: driver.drivers.shortName,
           url: driver.drivers.url,
+          image: getDriverImageUrl(driver.drivers.driverId),
           points: driver.driverClassifications.points,
           position: driver.driverClassifications.position,
           wins: driver.driverClassifications.wins,

--- a/app/api/drivers/[driverId]/route.ts
+++ b/app/api/drivers/[driverId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { SITE_URL } from "@/lib/constants"
-import { apiNotFound } from "@/lib/utils"
+import { apiNotFound, getDriverImageUrl } from "@/lib/utils"
 import { BaseApiResponse } from "@/lib/definitions"
 import { db } from "@/db"
 import { drivers } from "@/db/migrations/schema"
@@ -42,6 +42,7 @@ export async function GET(request: Request, context: any) {
         number: driver.number,
         shortName: driver.shortName,
         url: driver.url,
+        image: getDriverImageUrl(driver.driverId),
       }
     })
 
@@ -49,7 +50,10 @@ export async function GET(request: Request, context: any) {
       api: SITE_URL,
       url: request.url,
       total: driverData.length,
-      driver: driverData,
+      driver: driverData.map((driver) => ({
+        ...driver,
+        image: getDriverImageUrl(driver.driverId),
+      })),
     }
 
     return NextResponse.json(response, {

--- a/app/api/drivers/route.ts
+++ b/app/api/drivers/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { SITE_URL } from "@/lib/constants"
-import { apiNotFound, getLimitAndOffset } from "@/lib/utils"
+import { apiNotFound, getDriverImageUrl, getLimitAndOffset } from "@/lib/utils"
 import { BaseApiResponse } from "@/lib/definitions"
 import { db } from "@/db"
 import { drivers } from "@/db/migrations/schema"
@@ -29,26 +29,18 @@ export async function GET(request: Request) {
       return apiNotFound(request, "No drivers found.")
     }
 
-    driversData.forEach((driver) => {
-      return {
-        driverId: driver.driverId,
-        name: driver.name,
-        surname: driver.surname,
-        country: driver.nationality,
-        birthday: driver.birthday,
-        number: driver.number,
-        shortName: driver.shortName,
-        url: driver.url,
-      }
-    })
+    const driversWithImages = driversData.map((driver) => ({
+      ...driver,
+      image: getDriverImageUrl(driver.driverId),
+    }))
 
     const response: ApiResponse = {
       api: SITE_URL,
       url: request.url,
       limit: limit,
       offset: offset,
-      total: driversData.length,
-      drivers: driversData,
+      total: driversWithImages.length,
+      drivers: driversWithImages,
     }
 
     return NextResponse.json(response, {

--- a/app/api/drivers/search/route.ts
+++ b/app/api/drivers/search/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { SITE_URL } from "@/lib/constants"
-import { apiNotFound, getLimitAndOffset } from "@/lib/utils"
+import { apiNotFound, getDriverImageUrl, getLimitAndOffset } from "@/lib/utils"
 import { BaseApiResponse } from "@/lib/definitions"
 import { db } from "@/db"
 import { drivers } from "@/db/migrations/schema"
@@ -46,6 +46,7 @@ export async function GET(request: Request) {
         number: driver.number,
         shortName: driver.shortName,
         url: driver.url,
+        image: getDriverImageUrl(driver.driverId),
       }
     })
 
@@ -56,7 +57,10 @@ export async function GET(request: Request) {
       offset: offset,
       query: queryParams.get("q") ?? "",
       total: driversData.length,
-      drivers: driversData,
+      drivers: driversData.map((driver) => ({
+        ...driver,
+        image: getDriverImageUrl(driver.driverId),
+      })),
     }
 
     return NextResponse.json(response, {

--- a/app/data/announce.json
+++ b/app/data/announce.json
@@ -1,4 +1,4 @@
 {
-  "announce": "Data updated after the 2026 Japanese GP",
-  "link": "https://f1api.dev/api/2026/3/race"
+  "announce": "Data updated after the 2026 Canadian GP",
+  "link": "https://f1api.dev/api/2026/7/race"
 }

--- a/app/data/announce.json
+++ b/app/data/announce.json
@@ -1,4 +1,4 @@
 {
-  "announce": "Data updated after the 2026 Australian GP",
-  "link": "https://f1api.dev/api/2026/1/race"
+  "announce": "Data updated after the 2026 Japanese GP",
+  "link": "https://f1api.dev/api/2026/3/race"
 }

--- a/app/data/announce.json
+++ b/app/data/announce.json
@@ -1,4 +1,4 @@
 {
-  "announce": "Data updated after the 2026 British GP",
-  "link": "https://f1api.dev/api/2026/11/race"
+  "announce": "Data updated after the 2026 Belgian GP",
+  "link": "https://f1api.dev/api/2026/10/race"
 }

--- a/app/data/announce.json
+++ b/app/data/announce.json
@@ -1,4 +1,4 @@
 {
-  "announce": "Data updated after the 2026 Austrian GP",
-  "link": "https://f1api.dev/api/2026/10/race"
+  "announce": "Data updated after the 2026 British GP",
+  "link": "https://f1api.dev/api/2026/11/race"
 }

--- a/app/data/announce.json
+++ b/app/data/announce.json
@@ -1,4 +1,4 @@
 {
-  "announce": "Data updated after the 2026 Canadian GP",
-  "link": "https://f1api.dev/api/2026/7/race"
+  "announce": "Data updated after the 2026 Austrian GP",
+  "link": "https://f1api.dev/api/2026/10/race"
 }

--- a/lib/scrap/index.js
+++ b/lib/scrap/index.js
@@ -1,27 +1,27 @@
-import { chromium } from "playwright"
-import { getRaceResults } from "./race.js"
-import { getQualyResults } from "./qualy.js"
-import { getPracticeResults } from "./fp.js"
-import { getSprintRaceResults } from "./sprint/race.js"
-import { getSprintQualyResults } from "./sprint/qualy.js"
-import { updateDriversChampionship } from "./championships/drivers.js"
-import { updateTeamsChampionship } from "./championships/teams.js"
-;(async () => {
-  const browser = await chromium.launch({ headless: false })
-  const context = await browser.newContext()
+import { chromium } from "playwright";
+import { getRaceResults } from "./race.js";
+import { getQualyResults } from "./qualy.js";
+import { getPracticeResults } from "./fp.js";
+import { getSprintRaceResults } from "./sprint/race.js";
+import { getSprintQualyResults } from "./sprint/qualy.js";
+import { updateDriversChampionship } from "./championships/drivers.js";
+import { updateTeamsChampionship } from "./championships/teams.js";
+(async () => {
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
 
-  const page = await context.newPage()
-  const year = 2026
-  const race = "australian"
+  const page = await context.newPage();
+  const year = 2026;
+  const race = "canadian";
 
-  await getPracticeResults(year, race, page)
+  //await getPracticeResults(year, race, page);
   //await getQualyResults(year, race, page)
   //await getSprintQualyResults(year, race, page)
   //await getSprintRaceResults(year, race, page)
-  //await getRaceResults(year, race, page)
-  //await updateDriversChampionship(year, page)
-  //await updateTeamsChampionship(year, page)
+  //await getRaceResults(year, race, page);
+  //await updateDriversChampionship(year, page);
+  await updateTeamsChampionship(year, page);
 
-  await context.close()
-  await browser.close()
-})()
+  await context.close();
+  await browser.close();
+})();

--- a/lib/scrap/index.js
+++ b/lib/scrap/index.js
@@ -12,15 +12,15 @@ import { updateTeamsChampionship } from "./championships/teams.js"
 
   const page = await context.newPage()
   const year = 2026
-  const race = "austrian"
+  const race = "belgian"
 
-  //await getPracticeResults(year, race, page)
+  await getPracticeResults(year, race, page)
   //await getQualyResults(year, race, page)
   //await getSprintQualyResults(year, race, page)
   //await getSprintRaceResults(year, race, page)
   //await getRaceResults(year, race, page)
   //await updateDriversChampionship(year, page)
-  await updateTeamsChampionship(year, page)
+  //await updateTeamsChampionship(year, page)
 
   await context.close()
   await browser.close()

--- a/lib/scrap/index.js
+++ b/lib/scrap/index.js
@@ -1,27 +1,27 @@
-import { chromium } from "playwright";
-import { getRaceResults } from "./race.js";
-import { getQualyResults } from "./qualy.js";
-import { getPracticeResults } from "./fp.js";
-import { getSprintRaceResults } from "./sprint/race.js";
-import { getSprintQualyResults } from "./sprint/qualy.js";
-import { updateDriversChampionship } from "./championships/drivers.js";
-import { updateTeamsChampionship } from "./championships/teams.js";
-(async () => {
-  const browser = await chromium.launch({ headless: false });
-  const context = await browser.newContext();
+import { chromium } from "playwright"
+import { getRaceResults } from "./race.js"
+import { getQualyResults } from "./qualy.js"
+import { getPracticeResults } from "./fp.js"
+import { getSprintRaceResults } from "./sprint/race.js"
+import { getSprintQualyResults } from "./sprint/qualy.js"
+import { updateDriversChampionship } from "./championships/drivers.js"
+import { updateTeamsChampionship } from "./championships/teams.js"
+;(async () => {
+  const browser = await chromium.launch({ headless: false })
+  const context = await browser.newContext()
 
-  const page = await context.newPage();
-  const year = 2026;
-  const race = "canadian";
+  const page = await context.newPage()
+  const year = 2026
+  const race = "austrian"
 
-  //await getPracticeResults(year, race, page);
+  //await getPracticeResults(year, race, page)
   //await getQualyResults(year, race, page)
   //await getSprintQualyResults(year, race, page)
   //await getSprintRaceResults(year, race, page)
-  //await getRaceResults(year, race, page);
-  //await updateDriversChampionship(year, page);
-  await updateTeamsChampionship(year, page);
+  //await getRaceResults(year, race, page)
+  //await updateDriversChampionship(year, page)
+  await updateTeamsChampionship(year, page)
 
-  await context.close();
-  await browser.close();
-})();
+  await context.close()
+  await browser.close()
+})()

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -74,3 +74,7 @@ export function convertToTimezone(
     return { date, time } // fallback to original on error
   }
 }
+
+export function getDriverImageUrl(driverId: string): string {
+  return `https://media.formula1.com/d_driver_fallback_image.png/content/dam/fom-website/drivers/2024Drivers/${driverId}.jpg.img.1920.medium.jpg`;
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,1223 @@
+openapi: 3.0.3
+info:
+  title: F1 API
+  description: OpenAPI specification for the F1 API endpoints.
+  version: 1.0.0
+servers:
+  - url: https://f1api.dev
+    description: Production server
+tags:
+  - name: circuits
+  - name: drivers
+  - name: races
+  - name: seasons
+  - name: standings
+  - name: teams
+paths:
+  /api/{year}/{round}/fp1:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of the free practice 1 of a race based on the year and the round"
+      description: "Retrieve the information of the free practice 1 of a race based on the year and the round."
+      operationId: getYearRoundFp1
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - in: path
+          name: round
+          required: true
+          description: "Race round number within the season."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/{round}/fp2:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of the free practice 2 of a race based on the year and the round"
+      description: "Retrieve the information of the free practice 2 of a race based on the year and the round."
+      operationId: getYearRoundFp2
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - in: path
+          name: round
+          required: true
+          description: "Race round number within the season."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/{round}/fp3:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of the free practice 3 of a race based on the year and the round"
+      description: "Retrieve the information of the free practice 3 of a race based on the year and the round."
+      operationId: getYearRoundFp3
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - in: path
+          name: round
+          required: true
+          description: "Race round number within the season."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/{round}/qualy:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of the qualy of a race based on the year and the round"
+      description: "Retrieve the information of the qualy of a race based on the year and the round."
+      operationId: getYearRoundQualy
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - in: path
+          name: round
+          required: true
+          description: "Race round number within the season."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/{round}/race:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of a specific race based on the year and the round"
+      description: "Retrieve the information of a specific race based on the year and the round."
+      operationId: getYearRoundRace
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - in: path
+          name: round
+          required: true
+          description: "Race round number within the season."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/{round}:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of a race based on the year and the round"
+      description: "Retrieve the information of a race based on the year and the round."
+      operationId: getYearRound
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - in: path
+          name: round
+          required: true
+          description: "Race round number within the season."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/{round}/sprint/qualy:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of a sprint qualy (if exist) based on the year and the round"
+      description: "Retrieve the information of a sprint qualy (if exist) based on the year and the round."
+      operationId: getYearRoundSprintQualy
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - in: path
+          name: round
+          required: true
+          description: "Race round number within the season."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/{round}/sprint/race:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of a sprint race (if exist) based on the year and the round"
+      description: "Retrieve the information of a sprint race (if exist) based on the year and the round."
+      operationId: getYearRoundSprintRace
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - in: path
+          name: round
+          required: true
+          description: "Race round number within the season."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/circuits:
+    get:
+      tags:
+        - circuits
+      summary: "Retrieve a list of the circuits of the specific F1 season"
+      description: "Retrieve a list of the circuits of the specific F1 season."
+      operationId: getYearCircuits
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/compare/{driverId1}/{driverId2}:
+    get:
+      tags:
+        - drivers
+      summary: "Compare the head to head between two drivers in a season"
+      description: "Compare the head to head between two drivers in a season."
+      operationId: getYearCompareDriverId1DriverId2
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - in: path
+          name: driverId1
+          required: true
+          description: "Path parameter: driverId1."
+          schema:
+            type: string
+        - in: path
+          name: driverId2
+          required: true
+          description: "Path parameter: driverId2."
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/constructors-championship:
+    get:
+      tags:
+        - standings
+      summary: "Retrieve the constructors championship standing of the specific season"
+      description: "Retrieve the constructors championship standing of the specific season."
+      operationId: getYearConstructorsChampionship
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/drivers-championship:
+    get:
+      tags:
+        - standings
+      summary: "Retrieve the drivers championship standing of the specific season"
+      description: "Retrieve the drivers championship standing of the specific season."
+      operationId: getYearDriversChampionship
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/drivers/{driverId}:
+    get:
+      tags:
+        - drivers
+      summary: "Retrieve the results of the specific driver of the specific year"
+      description: "Retrieve the results of the specific driver of the specific year."
+      operationId: getYearDriversDriverId
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - in: path
+          name: driverId
+          required: true
+          description: "Path parameter: driverId."
+          schema:
+            type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/drivers:
+    get:
+      tags:
+        - drivers
+      summary: "Retrieve the list of the drivers of the specific year"
+      description: "Retrieve the list of the drivers of the specific year."
+      operationId: getYearDrivers
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}:
+    get:
+      tags:
+        - seasons
+      summary: "Retrieve the races of the specific year"
+      description: "Retrieve the races of the specific year."
+      operationId: getYear
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/teams/{teamId}/drivers:
+    get:
+      tags:
+        - drivers
+      summary: "Retrieve a list of all the drivers of a team based on the teamId and the specific year"
+      description: "Retrieve a list of all the drivers of a team based on the teamId and the specific year."
+      operationId: getYearTeamsTeamIdDrivers
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - in: path
+          name: teamId
+          required: true
+          description: "Path parameter: teamId."
+          schema:
+            type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/teams/{teamId}:
+    get:
+      tags:
+        - teams
+      summary: "Retrieve the data of a team based on his id and the specific year"
+      description: "Retrieve the data of a team based on his id and the specific year."
+      operationId: getYearTeamsTeamId
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - in: path
+          name: teamId
+          required: true
+          description: "Path parameter: teamId."
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/{year}/teams:
+    get:
+      tags:
+        - teams
+      summary: "Retrieve the list of the teams of the specific year"
+      description: "Retrieve the list of the teams of the specific year."
+      operationId: getYearTeams
+      parameters:
+        - in: path
+          name: year
+          required: true
+          description: "Season year (for example 2024)."
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/circuits/{circuitId}:
+    get:
+      tags:
+        - circuits
+      summary: "Retrieve data from /api/circuits/{circuitId}"
+      description: "Retrieve data from /api/circuits/{circuitId}."
+      operationId: getCircuitsCircuitId
+      parameters:
+        - in: path
+          name: circuitId
+          required: true
+          description: "Path parameter: circuitId."
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/circuits:
+    get:
+      tags:
+        - circuits
+      summary: "Retrieve the list of all the F1 circuits"
+      description: "Retrieve the list of all the F1 circuits."
+      operationId: getCircuits
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/circuits/search:
+    get:
+      tags:
+        - circuits
+      summary: "Search with a q parameter for a circuit or a list of circuits"
+      description: "Search with a q parameter for a circuit or a list of circuits. Based on his name, city or country."
+      operationId: getCircuitsSearch
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/q'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/constructors-championship:
+    get:
+      tags:
+        - standings
+      summary: "Retrieve the constructors championship standing of the current season"
+      description: "Retrieve the constructors championship standing of the current season."
+      operationId: getCurrentConstructorsChampionship
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/drivers-championship:
+    get:
+      tags:
+        - standings
+      summary: "Retrieve the drivers championship standing of the current season"
+      description: "Retrieve the drivers championship standing of the current season."
+      operationId: getCurrentDriversChampionship
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/drivers/{driverId}:
+    get:
+      tags:
+        - drivers
+      summary: "Retrieve the results of the specific driver of the current year"
+      description: "Retrieve the results of the specific driver of the current year."
+      operationId: getCurrentDriversDriverId
+      parameters:
+        - in: path
+          name: driverId
+          required: true
+          description: "Path parameter: driverId."
+          schema:
+            type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/drivers:
+    get:
+      tags:
+        - drivers
+      summary: "Retrieve the list of the drivers of the current year"
+      description: "Retrieve the list of the drivers of the current year."
+      operationId: getCurrentDrivers
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/last/fp1:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of the last free practice 1 of a race of the current year"
+      description: "Retrieve the information of the last free practice 1 of a race of the current year."
+      operationId: getCurrentLastFp1
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/last/fp2:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of the last free practice 2 of a race of the current year"
+      description: "Retrieve the information of the last free practice 2 of a race of the current year."
+      operationId: getCurrentLastFp2
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/last/fp3:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of the last free practice 3 of a race of the current year"
+      description: "Retrieve the information of the last free practice 3 of a race of the current year."
+      operationId: getCurrentLastFp3
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/last/qualy:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of the last qualy of a race of the current year"
+      description: "Retrieve the information of the last qualy of a race of the current year."
+      operationId: getCurrentLastQualy
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/last/race:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the results of the last race of the current year"
+      description: "Retrieve the results of the last race of the current year."
+      operationId: getCurrentLastRace
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/last:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of the last race of the current year"
+      description: "Retrieve the information of the last race of the current year."
+      operationId: getCurrentLast
+      parameters:
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/last/sprint/qualy:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of a sprint qualy (if exist) based on the year and the round"
+      description: "Retrieve the information of a sprint qualy (if exist) based on the year and the round."
+      operationId: getCurrentLastSprintQualy
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/last/sprint/race:
+    get:
+      tags:
+        - races
+      summary: "Retrieve the information of a sprint race (if exist) based on the year and the round"
+      description: "Retrieve the information of a sprint race (if exist) based on the year and the round."
+      operationId: getCurrentLastSprintRace
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/next:
+    get:
+      tags:
+        - seasons
+      summary: "Retrieve the information of the next race of the current year"
+      description: "Retrieve the information of the next race of the current year."
+      operationId: getCurrentNext
+      parameters:
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current:
+    get:
+      tags:
+        - seasons
+      summary: "Retrieve the races of the current year"
+      description: "Retrieve the races of the current year."
+      operationId: getCurrent
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/timezone'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/teams/{teamId}/drivers:
+    get:
+      tags:
+        - drivers
+      summary: "Retrieve a list of all the drivers of a team based on the teamId and the current year"
+      description: "Retrieve a list of all the drivers of a team based on the teamId and the current year."
+      operationId: getCurrentTeamsTeamIdDrivers
+      parameters:
+        - in: path
+          name: teamId
+          required: true
+          description: "Path parameter: teamId."
+          schema:
+            type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/teams/{teamId}:
+    get:
+      tags:
+        - teams
+      summary: "Retrieve the data of a team based on his id and the current year"
+      description: "Retrieve the data of a team based on his id and the current year."
+      operationId: getCurrentTeamsTeamId
+      parameters:
+        - in: path
+          name: teamId
+          required: true
+          description: "Path parameter: teamId."
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/current/teams:
+    get:
+      tags:
+        - teams
+      summary: "Retrieve the list of the teams of the current year"
+      description: "Retrieve the list of the teams of the current year."
+      operationId: getCurrentTeams
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/drivers/{driverId}:
+    get:
+      tags:
+        - drivers
+      summary: "Retrieve a driver using his id"
+      description: "Retrieve a driver using his id."
+      operationId: getDriversDriverId
+      parameters:
+        - in: path
+          name: driverId
+          required: true
+          description: "Path parameter: driverId."
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/drivers:
+    get:
+      tags:
+        - drivers
+      summary: "Retrieve a list of all the Drivers who at least race one F1 race"
+      description: "Retrieve a list of all the Drivers who at least race one F1 race."
+      operationId: getDrivers
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/drivers/search:
+    get:
+      tags:
+        - drivers
+      summary: "Search with a q parameter for a driver or a list of drivers"
+      description: "Search with a q parameter for a driver or a list of drivers. Based on his name or surname."
+      operationId: getDriversSearch
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/q'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/seasons:
+    get:
+      tags:
+        - seasons
+      summary: "Retrieve a list of all F1 Seasons, since the first one (1950) to the latest"
+      description: "Retrieve a list of all F1 Seasons, since the first one (1950) to the latest."
+      operationId: getSeasons
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/teams/{teamId}:
+    get:
+      tags:
+        - teams
+      summary: "Retrieve a list of a team based on his id"
+      description: "Retrieve a list of a team based on his id."
+      operationId: getTeamsTeamId
+      parameters:
+        - in: path
+          name: teamId
+          required: true
+          description: "Path parameter: teamId."
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/teams:
+    get:
+      tags:
+        - teams
+      summary: "Retrieve a list of all the teams that participated in Formula 1 races"
+      description: "Retrieve a list of all the teams that participated in Formula 1 races."
+      operationId: getTeams
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+  /api/teams/search:
+    get:
+      tags:
+        - teams
+      summary: "Search with a q parameter for a team or a list of teams"
+      description: "Search with a q parameter for a team or a list of teams. Based on his name."
+      operationId: getTeamsSearch
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/q'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Resource not found
+        '500':
+          description: Internal server error
+components:
+  parameters:
+    limit:
+      in: query
+      name: limit
+      required: false
+      description: Number of records to return. Min 1, max 100.
+      schema:
+        type: integer
+        default: 30
+        minimum: 1
+        maximum: 100
+    offset:
+      in: query
+      name: offset
+      required: false
+      description: Number of records to skip before collecting the response.
+      schema:
+        type: integer
+        default: 0
+        minimum: 0
+        maximum: 10000
+    q:
+      in: query
+      name: q
+      required: false
+      description: Search term used by search endpoints.
+      schema:
+        type: string
+    timezone:
+      in: query
+      name: timezone
+      required: false
+      description: IANA timezone identifier used to convert date/time fields (for example Europe/Madrid).
+      schema:
+        type: string
+        example: Europe/Madrid


### PR DESCRIPTION
## Summary

Adds an  field to all driver-related API endpoints, generating image URLs from the Formula 1 media CDN based on the .

## Changes

- ****: New  utility function
- **12 endpoints updated** to include the  field in driver responses

## Endpoints affected

| Endpoint | Description |
|---|---|
|  | All drivers |
|  | Single driver |
|  | Driver search |
|  | Drivers by year |
|  | Driver by year & ID |
|  | Driver comparison |
|  | Championship by year |
|  | Team drivers by year |
|  | Current season drivers |
|  | Current driver by ID |
|  | Current championship |
|  | Current team drivers |

## Example response

```json
{
  "driverId": "alonso",
  "name": "Fernando",
  "surname": "Alonso",
  "image": "https://media.formula1.com/.../alonso.jpg"
}
```

## Verification

- TypeScript: `tsc --noEmit` passes ✅
- Lint: `next lint` passes ✅